### PR TITLE
Update to mio 0.8 and os_pipe 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rustc_version = "0.4.0"
 [dependencies]
 async-std = { version = "1.10.0", optional = true }
 char-device = { version = "0.10.0", optional = true }
-duplex = "0.9.0"
+duplex = "0.10.0"
 layered-io = { version = "0.10.0", optional = true }
 memchr = "2.3.4"
 parking = "2.0.0"
@@ -39,7 +39,7 @@ rustix = "0.31.0"
 anyhow = "1.0.38"
 cap-tempfile = "0.22.0"
 char-device = "0.10.0"
-duplex = { version = "0.9.0", features = ["char-device"] }
+duplex = { version = "0.10.0", features = ["char-device"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ rustc_version = "0.4.0"
 
 [dependencies]
 async-std = { version = "1.10.0", optional = true }
-char-device = { version = "0.9.0", optional = true }
+char-device = { version = "0.10.0", optional = true }
 duplex = "0.9.0"
-layered-io = { version = "0.9.0", optional = true }
+layered-io = { version = "0.10.0", optional = true }
 memchr = "2.3.4"
 parking = "2.0.0"
-socketpair = { version = "0.12.0", optional = true }
-system-interface = { version = "0.16.0", features = ["use_os_pipe", "socketpair"] }
-terminal-io = { version = "0.8.0", optional = true }
+socketpair = { version = "0.13.0", optional = true }
+system-interface = { version = "0.17.0", features = ["use_os_pipe", "socketpair"] }
+terminal-io = { version = "0.9.0", optional = true }
 tokio = { version = "1.8.1", optional = true, features = ["fs", "net"] }
 io-extras = { version = "0.12.0", features = ["os_pipe"] }
-utf8-io = { version = "0.8.0", optional = true }
+utf8-io = { version = "0.9.0", optional = true }
 io-lifetimes = { version = "0.4.0", default-features = false }
 
 # WASI doesn't support pipes yet
@@ -33,12 +33,12 @@ io-lifetimes = { version = "0.4.0", default-features = false }
 os_pipe = "1.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.27.0"
+rustix = "0.31.0"
 
 [dev-dependencies]
 anyhow = "1.0.38"
-cap-tempfile = "0.21.0"
-char-device = "0.9.0"
+cap-tempfile = "0.22.0"
+char-device = "0.10.0"
 duplex = { version = "0.9.0", features = ["char-device"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ rustc_version = "0.4.0"
 
 [dependencies]
 async-std = { version = "1.10.0", optional = true }
-char-device = { version = "0.8.0", optional = true }
-duplex = "0.8.0"
+char-device = { version = "0.9.0", optional = true }
+duplex = "0.9.0"
 layered-io = { version = "0.9.0", optional = true }
 memchr = "2.3.4"
 parking = "2.0.0"
-socketpair = { version = "0.11.0", optional = true }
+socketpair = { version = "0.12.0", optional = true }
 system-interface = { version = "0.16.0", features = ["use_os_pipe", "socketpair"] }
 terminal-io = { version = "0.8.0", optional = true }
 tokio = { version = "1.8.1", optional = true, features = ["fs", "net"] }
@@ -33,13 +33,13 @@ io-lifetimes = { version = "0.4.0", default-features = false }
 os_pipe = "1.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.26.2"
+rustix = "0.27.0"
 
 [dev-dependencies]
 anyhow = "1.0.38"
 cap-tempfile = "0.21.0"
-char-device = "0.8.0"
-duplex = { version = "0.8.0", features = ["char-device"] }
+char-device = "0.9.0"
+duplex = { version = "0.9.0", features = ["char-device"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ socketpair = { version = "0.11.0", optional = true }
 system-interface = { version = "0.16.0", features = ["use_os_pipe", "socketpair"] }
 terminal-io = { version = "0.8.0", optional = true }
 tokio = { version = "1.8.1", optional = true, features = ["fs", "net"] }
-io-extras = { version = "0.11.0", features = ["os_pipe"] }
+io-extras = { version = "0.12.0", features = ["os_pipe"] }
 utf8-io = { version = "0.8.0", optional = true }
-io-lifetimes = { version = "0.3.3", default-features = false }
+io-lifetimes = { version = "0.4.0", default-features = false }
 
 # WASI doesn't support pipes yet
 [target.'cfg(not(target_os = "wasi"))'.dependencies]
-os_pipe = "0.9.2"
+os_pipe = "1.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
 rustix = "0.26.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ categories = ["rust-patterns"]
 repository = "https://github.com/sunfishcode/io-streams"
 exclude = ["/.github"]
 
-[build-dependencies]
-rustc_version = "0.4.0"
-
 [dependencies]
 async-std = { version = "1.10.0", optional = true }
 char-device = { version = "0.10.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ rustc_version = "0.4.0"
 async-std = { version = "1.10.0", optional = true }
 char-device = { version = "0.10.0", optional = true }
 duplex = "0.10.0"
-layered-io = { version = "0.10.0", optional = true }
+layered-io = { version = "0.11.0", optional = true }
 memchr = "2.3.4"
 parking = "2.0.0"
 socketpair = { version = "0.13.0", optional = true }
 system-interface = { version = "0.17.0", features = ["use_os_pipe", "socketpair"] }
-terminal-io = { version = "0.9.0", optional = true }
+terminal-io = { version = "0.10.0", optional = true }
 tokio = { version = "1.8.1", optional = true, features = ["fs", "net"] }
 io-extras = { version = "0.12.0", features = ["os_pipe"] }
 utf8-io = { version = "0.9.0", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -1,31 +1,54 @@
+use std::env::var;
+use std::io::Write;
+
 fn main() {
-    if let rustc_version::Channel::Nightly = rustc_version::version_meta()
-        .expect("query rustc release channel")
-        .channel
-    {
-        for feature in &[
-            "can_vector",         // https://github.com/rust-lang/rust/issues/69941
-            "clamp",              // https://github.com/rust-lang/rust/issues/44095
-            "extend_one",         // https://github.com/rust-lang/rust/issues/72631
-            "pattern",            // https://github.com/rust-lang/rust/issues/27721
-            "seek_convenience",   // https://github.com/rust-lang/rust/issues/59359
-            "seek_stream_len ",   // https://github.com/rust-lang/rust/issues/59359
-            "shrink_to",          // https://github.com/rust-lang/rust/issues/56431
-            "toowned_clone_into", // https://github.com/rust-lang/rust/issues/41263
-            "try_reserve",        // https://github.com/rust-lang/rust/issues/56431
-            "unix_socket_peek",   // https://github.com/rust-lang/rust/issues/76923
-            "windows_by_handle",  // https://github.com/rust-lang/rust/issues/63010
-            "with_options",       // https://github.com/rust-lang/rust/issues/65439
-            "write_all_vectored", // https://github.com/rust-lang/rust/issues/70436
-            "doc_cfg",            // https://github.com/rust-lang/rust/issues/43781
-            // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
-            "windows_file_type_ext",
-        ] {
-            println!("cargo:rustc-cfg={}", feature);
-        }
-    }
+    use_feature_or_nothing("can_vector"); // https://github.com/rust-lang/rust/issues/69941
+    use_feature_or_nothing("clamp"); // https://github.com/rust-lang/rust/issues/44095
+    use_feature_or_nothing("extend_one"); // https://github.com/rust-lang/rust/issues/72631
+    use_feature_or_nothing("pattern"); // https://github.com/rust-lang/rust/issues/27721
+    use_feature_or_nothing("seek_convenience"); // https://github.com/rust-lang/rust/issues/59359
+    use_feature_or_nothing("seek_stream_len"); // https://github.com/rust-lang/rust/issues/59359
+    use_feature_or_nothing("shrink_to"); // https://github.com/rust-lang/rust/issues/56431
+    use_feature_or_nothing("toowned_clone_into"); // https://github.com/rust-lang/rust/issues/41263
+    use_feature_or_nothing("try_reserve"); // https://github.com/rust-lang/rust/issues/56431
+    use_feature_or_nothing("unix_socket_peek"); // https://github.com/rust-lang/rust/issues/76923
+    use_feature_or_nothing("windows_by_handle"); // https://github.com/rust-lang/rust/issues/63010
+    use_feature_or_nothing("with_options"); // https://github.com/rust-lang/rust/issues/65439
+    use_feature_or_nothing("write_all_vectored"); // https://github.com/rust-lang/rust/issues/70436
+                                                  // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
+    use_feature_or_nothing("windows_file_type_ext");
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn use_feature_or_nothing(feature: &str) {
+    if has_feature(feature) {
+        use_feature(feature);
+    }
+}
+
+fn use_feature(feature: &str) {
+    println!("cargo:rustc-cfg={}", feature);
+}
+
+/// Test whether the rustc at `var("RUSTC")` supports the given feature.
+fn has_feature(feature: &str) -> bool {
+    let out_dir = var("OUT_DIR").unwrap();
+    let rustc = var("RUSTC").unwrap();
+
+    let mut child = std::process::Command::new(rustc)
+        .arg("--crate-type=rlib") // Don't require `main`.
+        .arg("--emit=metadata") // Do as little as possible but still parse.
+        .arg("--out-dir")
+        .arg(out_dir) // Put the output somewhere inconsequential.
+        .arg("-") // Read from stdin.
+        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
+        .spawn()
+        .unwrap();
+
+    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+
+    child.wait().unwrap().success()
 }


### PR DESCRIPTION
mio's `TcpSocket` was removed in favor of socket2.