### PR TITLE
Add `StreamWriter::stderr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1.8.1", optional = true, features = ["fs", "net"] }
 io-extras = { version = "0.18.0", features = ["os_pipe"] }
 utf8-io = { version = "0.19.0", optional = true }
 io-lifetimes = { version = "2.0.0", features = ["os_pipe"], default-features = false }
+paste = "1.0.15"
 
 # WASI doesn't support pipes yet
 [target.'cfg(not(target_os = "wasi"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ tokio = { version = "1.8.1", optional = true, features = ["fs", "net"] }
 io-extras = { version = "0.18.0", features = ["os_pipe"] }
 utf8-io = { version = "0.19.0", optional = true }
 io-lifetimes = { version = "2.0.0", features = ["os_pipe"], default-features = false }
-paste = "1.0.15"
 
 # WASI doesn't support pipes yet
 [target.'cfg(not(target_os = "wasi"))'.dependencies]

--- a/src/lockers.rs
+++ b/src/lockers.rs
@@ -5,7 +5,8 @@ use io_lifetimes::AsFilelike;
 use io_lifetimes::{AsFd, BorrowedFd};
 use os_pipe::PipeReader;
 use parking::{Parker, Unparker};
-use std::io::{self, stdin, stdout};
+use paste::paste;
+use std::io;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(target_os = "wasi")]
@@ -23,12 +24,6 @@ use {
     std::os::windows::io::{AsRawHandle, RawHandle},
 };
 
-// Statically track whether stdin and stdout are claimed. This allows us to
-// issue an error if they're ever claimed multiple times, instead of just
-// hanging.
-static STDIN_CLAIMED: AtomicBool = AtomicBool::new(false);
-static STDOUT_CLAIMED: AtomicBool = AtomicBool::new(false);
-
 // The locker thread just acquires a lock and parks, so it doesn't need much
 // memory. Rust adjusts this up to `PTHREAD_STACK_MIN`/etc. as needed.
 #[cfg(not(target_os = "freebsd"))]
@@ -39,243 +34,136 @@ const LOCKER_STACK_SIZE: usize = 64;
 #[cfg(target_os = "freebsd")]
 const LOCKER_STACK_SIZE: usize = 32 * 1024;
 
-/// This class acquires a lock on `stdin` and prevents applications from
-/// accidentally accessing it through other means.
-pub(crate) struct StdinLocker {
-    #[cfg(not(windows))]
-    raw_fd: RawFd,
-    #[cfg(windows)]
-    raw_handle: RawHandle,
-    unparker: Unparker,
-    join_handle: Option<JoinHandle<()>>,
-}
+macro_rules! std_locker {
+    ($name: ident) => {
+        paste! {
+            static [<$name:upper _CLAIMED>]: AtomicBool = AtomicBool::new(false);
 
-/// This class acquires a lock on `stdout` and prevents applications from
-/// accidentally accessing it through other means.
-pub(crate) struct StdoutLocker {
-    #[cfg(not(windows))]
-    raw_fd: RawFd,
-    #[cfg(windows)]
-    raw_handle: RawHandle,
-    unparker: Unparker,
-    join_handle: Option<JoinHandle<()>>,
-}
-
-impl StdinLocker {
-    /// An `InputByteStream` can take the value of the process' stdin, in which
-    /// case we want it to have exclusive access to `stdin`. Lock the Rust
-    /// standard library's `stdin` to prevent accidental misuse.
-    ///
-    /// Fails if a `StdinLocker` instance already exists.
-    pub(crate) fn new() -> io::Result<Self> {
-        if STDIN_CLAIMED
-            .compare_exchange(false, true, SeqCst, SeqCst)
-            .is_ok()
-        {
-            // `StdinLock` is not `Send`. To let `StdinLocker` be send, hold
-            // the lock on a parked thread.
-            let parker = Parker::new();
-            let unparker = parker.unparker();
-            let stdin = stdin();
-            #[cfg(not(windows))]
-            let raw_fd = stdin.as_raw_fd();
-            #[cfg(windows)]
-            let raw_handle = stdin.as_raw_handle();
-            let join_handle = Some(
-                thread::Builder::new()
-                    .name("ensure exclusive access to stdin".to_owned())
-                    .stack_size(LOCKER_STACK_SIZE)
-                    .spawn(move || {
-                        let _lock = stdin.lock();
-                        parker.park()
-                    })?,
-            );
-
-            Ok(Self {
+            /// This class acquires a lock on `<$name>` and prevents applications from
+            /// accidentally accessing it through other means.
+            pub(crate) struct [<$name:camel Locker>] {
                 #[cfg(not(windows))]
-                raw_fd,
+                raw_fd: RawFd,
                 #[cfg(windows)]
-                raw_handle,
-                unparker,
-                join_handle,
-            })
-        } else {
-            Err(io::Error::new(
-                io::ErrorKind::Other,
-                "attempted dual-ownership of stdin",
-            ))
-        }
-    }
-}
+                raw_handle: RawHandle,
+                unparker: Unparker,
+                join_handle: Option<JoinHandle<()>>,
+            }
 
-impl StdoutLocker {
-    /// An `OutputByteStream` can take the value of the process' stdout, in
-    /// which case we want it to have exclusive access to `stdout`. Lock the
-    /// Rust standard library's `stdout` to prevent accidental misuse.
-    ///
-    /// Fails if a `StdoutLocker` instance already exists.
-    pub(crate) fn new() -> io::Result<Self> {
-        if STDOUT_CLAIMED
-            .compare_exchange(false, true, SeqCst, SeqCst)
-            .is_ok()
-        {
-            // `StdoutLock` is not `Send`. To let `StdoutLocker` be send, hold
-            // the lock on a parked thread.
-            let parker = Parker::new();
-            let unparker = parker.unparker();
-            let stdout = stdout();
+            impl [<$name:camel Locker>] {
+                /// An `InputByteStream` can take the value of the process' <$name>, in which
+                /// case we want it to have exclusive access to `<$name>`. Lock the Rust
+                /// standard library's `<$name>` to prevent accidental misuse.
+                ///
+                /// Fails if a `<$name:camel>Locker` instance already exists.
+                pub(crate) fn new() -> io::Result<Self> {
+                    if [<$name:upper _CLAIMED>]
+                        .compare_exchange(false, true, SeqCst, SeqCst)
+                        .is_ok()
+                    {
+                        // `StdinLock` is not `Send`. To let `StdinLocker` be send, hold
+                        // the lock on a parked thread.
+                        let parker = Parker::new();
+                        let unparker = parker.unparker();
+                        let $name = io::$name();
+                        #[cfg(not(windows))]
+                        let raw_fd = $name.as_raw_fd();
+                        #[cfg(windows)]
+                        let raw_handle = $name.as_raw_handle();
+                        let join_handle = Some(
+                            thread::Builder::new()
+                                .name("ensure exclusive access to <$name>".to_owned())
+                                .stack_size(LOCKER_STACK_SIZE)
+                                .spawn(move || {
+                                    let _lock = $name.lock();
+                                    parker.park()
+                                })?,
+                        );
+
+                        Ok(Self {
+                            #[cfg(not(windows))]
+                            raw_fd,
+                            #[cfg(windows)]
+                            raw_handle,
+                            unparker,
+                            join_handle,
+                        })
+                    } else {
+                        Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            "attempted dual-ownership of <$name>",
+                        ))
+                    }
+                }
+            }
+
+            impl Drop for [<$name:camel Locker>] {
+                #[inline]
+                fn drop(&mut self) {
+                    self.unparker.unpark();
+                    self.join_handle.take().unwrap().join().unwrap();
+                    [<$name:upper _CLAIMED>].store(false, SeqCst);
+                }
+            }
+
             #[cfg(not(windows))]
-            let raw_fd = stdout.as_raw_fd();
+            impl AsRawFd for [<$name:camel Locker>] {
+                #[inline]
+                fn as_raw_fd(&self) -> RawFd {
+                    self.raw_fd
+                }
+            }
+
             #[cfg(windows)]
-            let raw_handle = stdout.as_raw_handle();
-            let join_handle = Some(
-                thread::Builder::new()
-                    .name("ensure exclusive access to stdout".to_owned())
-                    .stack_size(LOCKER_STACK_SIZE)
-                    .spawn(move || {
-                        let _lock = stdout.lock();
-                        parker.park()
-                    })?,
-            );
+            impl AsRawHandle for [<$name:camel Locker>] {
+                #[inline]
+                fn as_raw_handle(&self) -> RawHandle {
+                    self.raw_handle
+                }
+            }
 
-            Ok(Self {
-                #[cfg(not(windows))]
-                raw_fd,
-                #[cfg(windows)]
-                raw_handle,
-                unparker,
-                join_handle,
-            })
-        } else {
-            Err(io::Error::new(
-                io::ErrorKind::Other,
-                "attempted dual-ownership of stdout",
-            ))
+            #[cfg(windows)]
+            impl AsRawHandleOrSocket for [<$name:camel Locker>] {
+                #[inline]
+                fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
+                    RawHandleOrSocket::unowned_from_raw_handle(self.as_raw_handle())
+                }
+            }
+
+            #[cfg(not(windows))]
+            impl AsFd for [<$name:camel Locker>] {
+                #[inline]
+                fn as_fd(&self) -> BorrowedFd<'_> {
+                    unsafe { BorrowedFd::borrow_raw(self.raw_fd) }
+                }
+            }
+
+            #[cfg(windows)]
+            impl AsHandle for [<$name:camel Locker>] {
+                #[inline]
+                fn as_handle(&self) -> BorrowedHandle<'_> {
+                    unsafe { BorrowedHandle::borrow_raw(self.raw_handle) }
+                }
+            }
+
+            #[cfg(windows)]
+            impl AsHandleOrSocket for [<$name:camel Locker>] {
+                #[inline]
+                fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+                    unsafe {
+                        BorrowedHandleOrSocket::borrow_raw(RawHandleOrSocket::unowned_from_raw_handle(
+                            self.raw_handle,
+                        ))
+                    }
+                }
+            }
         }
-    }
+    };
 }
 
-impl Drop for StdinLocker {
-    #[inline]
-    fn drop(&mut self) {
-        self.unparker.unpark();
-        self.join_handle.take().unwrap().join().unwrap();
-        STDIN_CLAIMED.store(false, SeqCst);
-    }
-}
-
-impl Drop for StdoutLocker {
-    #[inline]
-    fn drop(&mut self) {
-        self.unparker.unpark();
-        self.join_handle.take().unwrap().join().unwrap();
-        STDOUT_CLAIMED.store(false, SeqCst);
-    }
-}
-
-#[cfg(not(windows))]
-impl AsRawFd for StdinLocker {
-    #[inline]
-    fn as_raw_fd(&self) -> RawFd {
-        self.raw_fd
-    }
-}
-
-#[cfg(not(windows))]
-impl AsRawFd for StdoutLocker {
-    #[inline]
-    fn as_raw_fd(&self) -> RawFd {
-        self.raw_fd
-    }
-}
-
-#[cfg(windows)]
-impl AsRawHandle for StdinLocker {
-    #[inline]
-    fn as_raw_handle(&self) -> RawHandle {
-        self.raw_handle
-    }
-}
-
-#[cfg(windows)]
-impl AsRawHandle for StdoutLocker {
-    #[inline]
-    fn as_raw_handle(&self) -> RawHandle {
-        self.raw_handle
-    }
-}
-
-#[cfg(windows)]
-impl AsRawHandleOrSocket for StdinLocker {
-    #[inline]
-    fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
-        RawHandleOrSocket::unowned_from_raw_handle(self.as_raw_handle())
-    }
-}
-
-#[cfg(windows)]
-impl AsRawHandleOrSocket for StdoutLocker {
-    #[inline]
-    fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
-        RawHandleOrSocket::unowned_from_raw_handle(self.as_raw_handle())
-    }
-}
-
-#[cfg(not(windows))]
-impl AsFd for StdinLocker {
-    #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
-        unsafe { BorrowedFd::borrow_raw(self.raw_fd) }
-    }
-}
-
-#[cfg(not(windows))]
-impl AsFd for StdoutLocker {
-    #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
-        unsafe { BorrowedFd::borrow_raw(self.raw_fd) }
-    }
-}
-
-#[cfg(windows)]
-impl AsHandle for StdinLocker {
-    #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
-        unsafe { BorrowedHandle::borrow_raw(self.raw_handle) }
-    }
-}
-
-#[cfg(windows)]
-impl AsHandle for StdoutLocker {
-    #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
-        unsafe { BorrowedHandle::borrow_raw(self.raw_handle) }
-    }
-}
-
-#[cfg(windows)]
-impl AsHandleOrSocket for StdinLocker {
-    #[inline]
-    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
-        unsafe {
-            BorrowedHandleOrSocket::borrow_raw(RawHandleOrSocket::unowned_from_raw_handle(
-                self.raw_handle,
-            ))
-        }
-    }
-}
-
-#[cfg(windows)]
-impl AsHandleOrSocket for StdoutLocker {
-    #[inline]
-    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
-        unsafe {
-            BorrowedHandleOrSocket::borrow_raw(RawHandleOrSocket::unowned_from_raw_handle(
-                self.raw_handle,
-            ))
-        }
-    }
-}
+std_locker!(stdin);
+std_locker!(stdout);
+std_locker!(stderr);
 
 impl ReadReady for StdinLocker {
     #[inline]

--- a/src/lockers.rs
+++ b/src/lockers.rs
@@ -5,8 +5,7 @@ use io_lifetimes::AsFilelike;
 use io_lifetimes::{AsFd, BorrowedFd};
 use os_pipe::PipeReader;
 use parking::{Parker, Unparker};
-use paste::paste;
-use std::io;
+use std::io::{self, stderr, stdin, stdout};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(target_os = "wasi")]
@@ -24,6 +23,13 @@ use {
     std::os::windows::io::{AsRawHandle, RawHandle},
 };
 
+// Statically track whether stdin and stdout are claimed. This allows us to
+// issue an error if they're ever claimed multiple times, instead of just
+// hanging.
+static STDIN_CLAIMED: AtomicBool = AtomicBool::new(false);
+static STDOUT_CLAIMED: AtomicBool = AtomicBool::new(false);
+static STDERR_CLAIMED: AtomicBool = AtomicBool::new(false);
+
 // The locker thread just acquires a lock and parks, so it doesn't need much
 // memory. Rust adjusts this up to `PTHREAD_STACK_MIN`/etc. as needed.
 #[cfg(not(target_os = "freebsd"))]
@@ -34,136 +40,363 @@ const LOCKER_STACK_SIZE: usize = 64;
 #[cfg(target_os = "freebsd")]
 const LOCKER_STACK_SIZE: usize = 32 * 1024;
 
-macro_rules! std_locker {
-    ($name: ident) => {
-        paste! {
-            static [<$name:upper _CLAIMED>]: AtomicBool = AtomicBool::new(false);
-
-            /// This class acquires a lock on `<$name>` and prevents applications from
-            /// accidentally accessing it through other means.
-            pub(crate) struct [<$name:camel Locker>] {
-                #[cfg(not(windows))]
-                raw_fd: RawFd,
-                #[cfg(windows)]
-                raw_handle: RawHandle,
-                unparker: Unparker,
-                join_handle: Option<JoinHandle<()>>,
-            }
-
-            impl [<$name:camel Locker>] {
-                /// An `InputByteStream` can take the value of the process' <$name>, in which
-                /// case we want it to have exclusive access to `<$name>`. Lock the Rust
-                /// standard library's `<$name>` to prevent accidental misuse.
-                ///
-                /// Fails if a `<$name:camel>Locker` instance already exists.
-                pub(crate) fn new() -> io::Result<Self> {
-                    if [<$name:upper _CLAIMED>]
-                        .compare_exchange(false, true, SeqCst, SeqCst)
-                        .is_ok()
-                    {
-                        // `StdinLock` is not `Send`. To let `StdinLocker` be send, hold
-                        // the lock on a parked thread.
-                        let parker = Parker::new();
-                        let unparker = parker.unparker();
-                        let $name = io::$name();
-                        #[cfg(not(windows))]
-                        let raw_fd = $name.as_raw_fd();
-                        #[cfg(windows)]
-                        let raw_handle = $name.as_raw_handle();
-                        let join_handle = Some(
-                            thread::Builder::new()
-                                .name("ensure exclusive access to <$name>".to_owned())
-                                .stack_size(LOCKER_STACK_SIZE)
-                                .spawn(move || {
-                                    let _lock = $name.lock();
-                                    parker.park()
-                                })?,
-                        );
-
-                        Ok(Self {
-                            #[cfg(not(windows))]
-                            raw_fd,
-                            #[cfg(windows)]
-                            raw_handle,
-                            unparker,
-                            join_handle,
-                        })
-                    } else {
-                        Err(io::Error::new(
-                            io::ErrorKind::Other,
-                            "attempted dual-ownership of <$name>",
-                        ))
-                    }
-                }
-            }
-
-            impl Drop for [<$name:camel Locker>] {
-                #[inline]
-                fn drop(&mut self) {
-                    self.unparker.unpark();
-                    self.join_handle.take().unwrap().join().unwrap();
-                    [<$name:upper _CLAIMED>].store(false, SeqCst);
-                }
-            }
-
-            #[cfg(not(windows))]
-            impl AsRawFd for [<$name:camel Locker>] {
-                #[inline]
-                fn as_raw_fd(&self) -> RawFd {
-                    self.raw_fd
-                }
-            }
-
-            #[cfg(windows)]
-            impl AsRawHandle for [<$name:camel Locker>] {
-                #[inline]
-                fn as_raw_handle(&self) -> RawHandle {
-                    self.raw_handle
-                }
-            }
-
-            #[cfg(windows)]
-            impl AsRawHandleOrSocket for [<$name:camel Locker>] {
-                #[inline]
-                fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
-                    RawHandleOrSocket::unowned_from_raw_handle(self.as_raw_handle())
-                }
-            }
-
-            #[cfg(not(windows))]
-            impl AsFd for [<$name:camel Locker>] {
-                #[inline]
-                fn as_fd(&self) -> BorrowedFd<'_> {
-                    unsafe { BorrowedFd::borrow_raw(self.raw_fd) }
-                }
-            }
-
-            #[cfg(windows)]
-            impl AsHandle for [<$name:camel Locker>] {
-                #[inline]
-                fn as_handle(&self) -> BorrowedHandle<'_> {
-                    unsafe { BorrowedHandle::borrow_raw(self.raw_handle) }
-                }
-            }
-
-            #[cfg(windows)]
-            impl AsHandleOrSocket for [<$name:camel Locker>] {
-                #[inline]
-                fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
-                    unsafe {
-                        BorrowedHandleOrSocket::borrow_raw(RawHandleOrSocket::unowned_from_raw_handle(
-                            self.raw_handle,
-                        ))
-                    }
-                }
-            }
-        }
-    };
+/// This class acquires a lock on `stdin` and prevents applications from
+/// accidentally accessing it through other means.
+pub(crate) struct StdinLocker {
+    #[cfg(not(windows))]
+    raw_fd: RawFd,
+    #[cfg(windows)]
+    raw_handle: RawHandle,
+    unparker: Unparker,
+    join_handle: Option<JoinHandle<()>>,
 }
 
-std_locker!(stdin);
-std_locker!(stdout);
-std_locker!(stderr);
+/// This class acquires a lock on `stdout` and prevents applications from
+/// accidentally accessing it through other means.
+pub(crate) struct StdoutLocker {
+    #[cfg(not(windows))]
+    raw_fd: RawFd,
+    #[cfg(windows)]
+    raw_handle: RawHandle,
+    unparker: Unparker,
+    join_handle: Option<JoinHandle<()>>,
+}
+
+/// This class acquires a lock on `stderr` and prevents applications from
+/// accidentally accessing it through other means.
+pub(crate) struct StderrLocker {
+    #[cfg(not(windows))]
+    raw_fd: RawFd,
+    #[cfg(windows)]
+    raw_handle: RawHandle,
+    unparker: Unparker,
+    join_handle: Option<JoinHandle<()>>,
+}
+
+impl StdinLocker {
+    /// An `InputByteStream` can take the value of the process' stdin, in which
+    /// case we want it to have exclusive access to `stdin`. Lock the Rust
+    /// standard library's `stdin` to prevent accidental misuse.
+    ///
+    /// Fails if a `StdinLocker` instance already exists.
+    pub(crate) fn new() -> io::Result<Self> {
+        if STDIN_CLAIMED
+            .compare_exchange(false, true, SeqCst, SeqCst)
+            .is_ok()
+        {
+            // `StdinLock` is not `Send`. To let `StdinLocker` be send, hold
+            // the lock on a parked thread.
+            let parker = Parker::new();
+            let unparker = parker.unparker();
+            let stdin = stdin();
+            #[cfg(not(windows))]
+            let raw_fd = stdin.as_raw_fd();
+            #[cfg(windows)]
+            let raw_handle = stdin.as_raw_handle();
+            let join_handle = Some(
+                thread::Builder::new()
+                    .name("ensure exclusive access to stdin".to_owned())
+                    .stack_size(LOCKER_STACK_SIZE)
+                    .spawn(move || {
+                        let _lock = stdin.lock();
+                        parker.park()
+                    })?,
+            );
+
+            Ok(Self {
+                #[cfg(not(windows))]
+                raw_fd,
+                #[cfg(windows)]
+                raw_handle,
+                unparker,
+                join_handle,
+            })
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "attempted dual-ownership of stdin",
+            ))
+        }
+    }
+}
+
+impl StdoutLocker {
+    /// An `OutputByteStream` can take the value of the process' stdout, in
+    /// which case we want it to have exclusive access to `stdout`. Lock the
+    /// Rust standard library's `stdout` to prevent accidental misuse.
+    ///
+    /// Fails if a `StdoutLocker` instance already exists.
+    pub(crate) fn new() -> io::Result<Self> {
+        if STDOUT_CLAIMED
+            .compare_exchange(false, true, SeqCst, SeqCst)
+            .is_ok()
+        {
+            // `StdoutLock` is not `Send`. To let `StdoutLocker` be send, hold
+            // the lock on a parked thread.
+            let parker = Parker::new();
+            let unparker = parker.unparker();
+            let stdout = stdout();
+            #[cfg(not(windows))]
+            let raw_fd = stdout.as_raw_fd();
+            #[cfg(windows)]
+            let raw_handle = stdout.as_raw_handle();
+            let join_handle = Some(
+                thread::Builder::new()
+                    .name("ensure exclusive access to stdout".to_owned())
+                    .stack_size(LOCKER_STACK_SIZE)
+                    .spawn(move || {
+                        let _lock = stdout.lock();
+                        parker.park()
+                    })?,
+            );
+
+            Ok(Self {
+                #[cfg(not(windows))]
+                raw_fd,
+                #[cfg(windows)]
+                raw_handle,
+                unparker,
+                join_handle,
+            })
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "attempted dual-ownership of stdout",
+            ))
+        }
+    }
+}
+
+impl StderrLocker {
+    /// An `OutputByteStream` can take the value of the process' stderr, in
+    /// which case we want it to have exclusive access to `stderr`. Lock the
+    /// Rust standard library's `stderr` to prevent accidental misuse.
+    ///
+    /// Fails if a `StderrLocker` instance already exists.
+    pub(crate) fn new() -> io::Result<Self> {
+        if STDOUT_CLAIMED
+            .compare_exchange(false, true, SeqCst, SeqCst)
+            .is_ok()
+        {
+            // `StderrLock` is not `Send`. To let `StderrLocker` be send, hold
+            // the lock on a parked thread.
+            let parker = Parker::new();
+            let unparker = parker.unparker();
+            let stderr = stderr();
+            #[cfg(not(windows))]
+            let raw_fd = stderr.as_raw_fd();
+            #[cfg(windows)]
+            let raw_handle = stderr.as_raw_handle();
+            let join_handle = Some(
+                thread::Builder::new()
+                    .name("ensure exclusive access to stderr".to_owned())
+                    .stack_size(LOCKER_STACK_SIZE)
+                    .spawn(move || {
+                        let _lock = stderr.lock();
+                        parker.park()
+                    })?,
+            );
+
+            Ok(Self {
+                #[cfg(not(windows))]
+                raw_fd,
+                #[cfg(windows)]
+                raw_handle,
+                unparker,
+                join_handle,
+            })
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "attempted dual-ownership of stderr",
+            ))
+        }
+    }
+}
+
+impl Drop for StdinLocker {
+    #[inline]
+    fn drop(&mut self) {
+        self.unparker.unpark();
+        self.join_handle.take().unwrap().join().unwrap();
+        STDIN_CLAIMED.store(false, SeqCst);
+    }
+}
+
+impl Drop for StdoutLocker {
+    #[inline]
+    fn drop(&mut self) {
+        self.unparker.unpark();
+        self.join_handle.take().unwrap().join().unwrap();
+        STDOUT_CLAIMED.store(false, SeqCst);
+    }
+}
+
+
+impl Drop for StderrLocker {
+    #[inline]
+    fn drop(&mut self) {
+        self.unparker.unpark();
+        self.join_handle.take().unwrap().join().unwrap();
+        STDERR_CLAIMED.store(false, SeqCst);
+    }
+}
+
+#[cfg(not(windows))]
+impl AsRawFd for StdinLocker {
+    #[inline]
+    fn as_raw_fd(&self) -> RawFd {
+        self.raw_fd
+    }
+}
+
+#[cfg(not(windows))]
+impl AsRawFd for StdoutLocker {
+    #[inline]
+    fn as_raw_fd(&self) -> RawFd {
+        self.raw_fd
+    }
+}
+
+#[cfg(not(windows))]
+impl AsRawFd for StderrLocker {
+    #[inline]
+    fn as_raw_fd(&self) -> RawFd {
+        self.raw_fd
+    }
+}
+
+#[cfg(windows)]
+impl AsRawHandle for StdinLocker {
+    #[inline]
+    fn as_raw_handle(&self) -> RawHandle {
+        self.raw_handle
+    }
+}
+
+#[cfg(windows)]
+impl AsRawHandle for StdoutLocker {
+    #[inline]
+    fn as_raw_handle(&self) -> RawHandle {
+        self.raw_handle
+    }
+}
+
+#[cfg(windows)]
+impl AsRawHandle for StderrLocker {
+    #[inline]
+    fn as_raw_handle(&self) -> RawHandle {
+        self.raw_handle
+    }
+}
+
+#[cfg(windows)]
+impl AsRawHandleOrSocket for StdinLocker {
+    #[inline]
+    fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
+        RawHandleOrSocket::unowned_from_raw_handle(self.as_raw_handle())
+    }
+}
+
+#[cfg(windows)]
+impl AsRawHandleOrSocket for StdoutLocker {
+    #[inline]
+    fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
+        RawHandleOrSocket::unowned_from_raw_handle(self.as_raw_handle())
+    }
+}
+
+#[cfg(windows)]
+impl AsRawHandleOrSocket for StderrLocker {
+    #[inline]
+    fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
+        RawHandleOrSocket::unowned_from_raw_handle(self.as_raw_handle())
+    }
+}
+
+#[cfg(not(windows))]
+impl AsFd for StdinLocker {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.raw_fd) }
+    }
+}
+
+#[cfg(not(windows))]
+impl AsFd for StdoutLocker {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.raw_fd) }
+    }
+}
+
+#[cfg(not(windows))]
+impl AsFd for StderrLocker {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.raw_fd) }
+    }
+}
+
+#[cfg(windows)]
+impl AsHandle for StdinLocker {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.raw_handle) }
+    }
+}
+
+#[cfg(windows)]
+impl AsHandle for StdoutLocker {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.raw_handle) }
+    }
+}
+
+#[cfg(windows)]
+impl AsHandle for StderrLocker {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        unsafe { BorrowedHandle::borrow_raw(self.raw_handle) }
+    }
+}
+
+#[cfg(windows)]
+impl AsHandleOrSocket for StdinLocker {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        unsafe {
+            BorrowedHandleOrSocket::borrow_raw(RawHandleOrSocket::unowned_from_raw_handle(
+                self.raw_handle,
+            ))
+        }
+    }
+}
+
+#[cfg(windows)]
+impl AsHandleOrSocket for StdoutLocker {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        unsafe {
+            BorrowedHandleOrSocket::borrow_raw(RawHandleOrSocket::unowned_from_raw_handle(
+                self.raw_handle,
+            ))
+        }
+    }
+}
+
+#[cfg(windows)]
+impl AsHandleOrSocket for StderrLocker {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        unsafe {
+            BorrowedHandleOrSocket::borrow_raw(RawHandleOrSocket::unowned_from_raw_handle(
+                self.raw_handle,
+            ))
+        }
+    }
+}
 
 impl ReadReady for StdinLocker {
     #[inline]


### PR DESCRIPTION
It would be nice to be able to use the same API for `stderr` as for `stdin` and `stdout`.

Closes #16 