### PR TITLE
Add char_device and socketpair to the documentation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ use_tokio = ["tokio", "io-lifetimes/tokio"]
 #use_tokio_socketpair = ["use_socketpair", "socketpair/use_tokio", "duplex/use_tokio_socketpair", "system-interface/socketpair"]
 
 [package.metadata.docs.rs]
-features = []
+features = ["use_char_device", "use_socketpair"]
 #"use_async_std_char_device", "use_async_std_socketpair", "use_tokio_char_device", "use_tokio_socketpair"
 
 [lints.rust.unexpected_cfgs]


### PR DESCRIPTION
Add char_device and socketpair to the features used when generating documentation.